### PR TITLE
session_lockable was FUBAR [Finishes #96328360]

### DIFF
--- a/devise_security_extension.gemspec
+++ b/devise_security_extension.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "devise_security_extension"
-  s.version = "0.7.2"
+  s.version = "0.7.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Marco Scholl", "Alexander Dreher"]
@@ -88,4 +88,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
   end
 end
-

--- a/lib/devise_security_extension/hooks/session_lockable.rb
+++ b/lib/devise_security_extension/hooks/session_lockable.rb
@@ -1,33 +1,22 @@
-Warden::Manager.after_authentication do |record, warden, options|
-  if record.respond_to?(:login_attempts)
-    record.update(login_attempts: 0, most_recent_attempt_at: nil)
+Warden::Manager.before_failure do |env, warden, options|
+  request_parameters = env['action_dispatch.request.request_parameters']
+  user_parameters = request_parameters['user'] if request_parameters
+  email = user_parameters['email'] if user_parameters
+  scope = warden[:scope].to_s.classify.constantize if warden[:scope]
+  record = scope.where(email: email).first if email && scope
+
+  if record && record.advanced_security_required?
+    record.update_attribute(:login_attempts, record.login_attempts + 1)
+    record.update_attribute(:most_recent_attempt_at, Time.now)
   end
 end
 
-Warden::Manager.before_failure do |record, warden, options|
-  if record.respond_to?(:login_attempts)
-    if record.advanced_security_required?
-      record.update(login_attempts: record.login_attempts + 1, most_recent_attempt_at: Time.now)
-    end
-  else
-    request_parameters = record['action_dispatch.request.request_parameters']
-    user_parameters = request_parameters['user'] if request_parameters
-    email = user_parameters['email'] if user_parameters
-    user = User.where(email: email).first if email
-
-    if user
-      if user.advanced_security_required?
-        user.login_attempts += 1
-        user.most_recent_attempt_at = Time.now
-        user.save
-      end
-    end
-  end
-end
-
-Warden::Manager.after_set_user do |user, auth, opts|
-  if user.login_attempts > 6 and user.most_recent_attempt_at >= 3.minutes.ago
+Warden::Manager.after_set_user do |record, auth, opts|
+  if record.login_attempts > 6 && record.most_recent_attempt_at >= 3.minutes.ago
     auth.logout
-    throw :warden, message: "Your account has been locked out. Please confirm your password and try back later."
+    throw :warden, message: 'Your account has been locked out. Please confirm your password and try back later.'
+  else
+    record.update_attribute(:login_attempts, 0)
+    record.update_attribute(:most_recent_attempt_at, nil)
   end
 end

--- a/lib/devise_security_extension/models/session_limitable.rb
+++ b/lib/devise_security_extension/models/session_limitable.rb
@@ -5,17 +5,14 @@ module Devise
     # SessionLimited ensures, that there is only one session usable per account at once.
     # If someone logs in, and some other is logging in with the same credentials,
     # the session from the first one is invalidated and not usable anymore.
-    # The first one is redirected to the sign page with a message, telling that 
+    # The first one is redirected to the sign page with a message, telling that
     # someone used his credentials to sign in.
     module SessionLimitable
       extend ActiveSupport::Concern
 
       def update_unique_session_id!(unique_session_id)
-        self.unique_session_id = unique_session_id
-
-        save(:validate => false)
+        self.update_attribute(:unique_session_id, unique_session_id)
       end
-
     end
   end
 end


### PR DESCRIPTION
- We were never resetting login_attempts
- after_authentication was being run before after_set_user
- before_failure was unnecessarily conditional
- before_failure was dependent on a User model

Napa dependencies remain. As a next step, this module should be moved to Napa.

@icebreaker @tarnelope 
